### PR TITLE
Get 'isAuthenticated' from ActivatedRoute instead of UserService

### DIFF
--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
-import { Router } from '@angular/router';
+import { Router, ActivatedRoute } from '@angular/router';
 
-import { ArticleListConfig, TagsService, UserService } from '../shared';
+import { ArticleListConfig, TagsService } from '../shared';
 
 @Component({
   selector: 'home-page',
@@ -11,8 +11,8 @@ import { ArticleListConfig, TagsService, UserService } from '../shared';
 export class HomeComponent implements OnInit {
   constructor(
     private router: Router,
-    private tagsService: TagsService,
-    private userService: UserService
+    private route: ActivatedRoute,
+    private tagsService: TagsService
   ) {}
 
   isAuthenticated: boolean;
@@ -21,18 +21,14 @@ export class HomeComponent implements OnInit {
   tagsLoaded = false;
 
   ngOnInit() {
-    this.userService.isAuthenticated.subscribe(
-      (authenticated) => {
-        this.isAuthenticated = authenticated;
+    this.isAuthenticated = this.route.snapshot.data['isAuthenticated'];
 
-        // set the article list accordingly
-        if (authenticated) {
-          this.setListTo('feed');
-        } else {
-          this.setListTo('all');
-        }
-      }
-    );
+    // set the article list accordingly
+    if (this.isAuthenticated) {
+      this.setListTo('feed');
+    } else {
+      this.setListTo('all');
+    }
 
     this.tagsService.getAll()
     .subscribe(tags => {


### PR DESCRIPTION
I noticed that HomeModule specifies a route resolver:
`{
    path: '',
    component: HomeComponent,
    resolve: {
      isAuthenticated: HomeAuthResolver
    }
  }`
but the HomeComponent was still using the UserService to get the authentication status. It works as is, but it is nice in my opinion to complete the example of using a resolver in the route config, by pulling isAuthenticated from the ActivatedRoute snapshot.

Please let me know if I missed anything in terms of contributing.