### PR TITLE
Fixed: Tag not saving when publishing articles

### DIFF
--- a/src/app/editor/editor.component.ts
+++ b/src/app/editor/editor.component.ts
@@ -64,6 +64,9 @@ export class EditorComponent implements OnInit {
     // update the model
     this.updateArticle(this.articleForm.value);
 
+    // update any single tag
+    this.addTag();
+
     // post the changes
     this.articlesService
     .save(this.article)


### PR DESCRIPTION
When the 'Publish Article" button pressed, an entered tag does not save.  Currently the only way to save tags is by typing them and hitting the Enter key. 

This small modification saves a tag that has been typed into the tags field when the 'Publish Article' button is clicked.  

It is arguable that a more natural and intuitive editing workflow involves adding/editing content (including tags) and saving all additions/edits with the single click of the 'Publish Article' button. 