### PR TITLE
fix(build): remove --aot from start script

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "scripts": {
     "ng": "ng",
-    "start": "ng serve --aot",
+    "start": "ng serve",
     "build": "ng build --prod",
     "test": "ng test",
     "lint": "ng lint",


### PR DESCRIPTION
This was my fault for suggesting to use `--aot`, sticking with `ng serve` is considered best practice right now