### PR TITLE
Issue #72. ErrorObservable needed to be passed the actual error.error object

### DIFF
--- a/src/app/shared/services/api.service.ts
+++ b/src/app/shared/services/api.service.ts
@@ -15,7 +15,7 @@ export class ApiService {
   ) {}
 
   private formatErrors(error: any) {
-    return new ErrorObservable(error.json());
+    return new ErrorObservable(error.error);
   }
 
   get(path: string, params: HttpParams = new HttpParams()): Observable<any> {

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -5,5 +5,6 @@
 
 export const environment = {
   production: false,
-  api_url: 'https://conduit.productionready.io/api'
+  //api_url: 'https://conduit.productionready.io/api'
+  api_url: 'http://localhost:3000/api'
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -5,6 +5,5 @@
 
 export const environment = {
   production: false,
-  //api_url: 'https://conduit.productionready.io/api'
-  api_url: 'http://localhost:3000/api'
+  api_url: 'https://conduit.productionready.io/api'
 };


### PR DESCRIPTION
ErrorObservable needed to be passed the error.error object, which has the actual error object. Later on, message is composed and displayed in the front.

Solves #72 