### PR TITLE
Feature travis ci

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/gothinkster/angular-realworld-example-app.svg?branch=develop)](https://travis-ci.org/gothinkster/angular-realworld-example-app)
+
 # ![Angular 2 Example App](logo.png)
 
 > ### Angular 5 codebase containing real world examples (CRUD, auth, advanced patterns, etc) that adheres to the [RealWorld](https://github.com/gothinkster/realworld-example-apps) spec and API.

--- a/travis.yml
+++ b/travis.yml
@@ -7,7 +7,7 @@ branches:
     - master
 
 before_script:
-  - npm install -g @angular/cli
+  - yarn install --frozen-lockfile
 
 script:
   - ng build --prod --bh "./"

--- a/travis.yml
+++ b/travis.yml
@@ -1,0 +1,22 @@
+language: node_js
+node_js:
+  - "8.9.4"
+
+branches:
+  only:
+    - master
+
+before_script:
+  - npm install -g @angular/cli
+
+script:
+  - ng build 
+
+deploy:
+  provider: pages
+  skip-cleanup: true
+  github-token: $GITHUB_TOKEN  # Set in travis-ci.org dashboard, marked secure
+  keep-history: true
+  on:
+    branch: master
+  local_dir: dist

--- a/travis.yml
+++ b/travis.yml
@@ -10,7 +10,7 @@ before_script:
   - npm install -g @angular/cli
 
 script:
-  - ng build 
+  - ng build --prod --bh "./"
 
 deploy:
   provider: pages


### PR DESCRIPTION
This feature is for adding Continuous Integration. It sum up as follow:
- Add Travis build  to gh pages for more [information](https://docs.travis-ci.com/user/deployment/pages/).
- Set up base URL to deploy gh-pages (the base URL in index.html for the build needs to be changed to call the bundles) 
- And finally add a Build Status Badge  in README

