### PR TITLE
Enable users implementing a File Upload action using the provided core services

### DIFF
--- a/src/app/core/interceptors/http.token.interceptor.ts
+++ b/src/app/core/interceptors/http.token.interceptor.ts
@@ -13,6 +13,9 @@ export class HttpTokenInterceptor implements HttpInterceptor {
       'Content-Type': 'application/json',
       'Accept': 'application/json'
     };
+    if ( req.body instanceof FormData ) {
+      delete headersConfig['Content-Type'];  // FormData present: Remove Content-Type as it's set by Browser
+    }
 
     const token = this.jwtService.getToken();
 

--- a/src/app/core/services/api.service.ts
+++ b/src/app/core/services/api.service.ts
@@ -24,16 +24,22 @@ export class ApiService {
   }
 
   put(path: string, body: Object = {}): Observable<any> {
+    if (!(body instanceof FormData)) {
+      body = JSON.stringify(body);
+    }
     return this.http.put(
       `${environment.api_url}${path}`,
-      JSON.stringify(body)
+      body
     ).pipe(catchError(this.formatErrors));
   }
 
   post(path: string, body: Object = {}): Observable<any> {
+    if (!(body instanceof FormData)) {
+      body = JSON.stringify(body);
+    }
     return this.http.post(
       `${environment.api_url}${path}`,
-      JSON.stringify(body)
+      body
     ).pipe(catchError(this.formatErrors));
   }
 


### PR DESCRIPTION
HTTP Interceptor and Core API services had to be patched to allow requests with a FormData in their body slip through the chain without losing their bodies and having their headers set incorrectly.