### PR TITLE
adding skipLibCheck to tsconfig to prevent linting libraries

### DIFF
--- a/src/tsconfig.app.json
+++ b/src/tsconfig.app.json
@@ -1,6 +1,7 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
+    "skipLibCheck": true,
     "outDir": "../out-tsc/app",
     "baseUrl": "./",
     "module": "es2015",


### PR DESCRIPTION
This fixes the type checking for existing libraries. Otherwise it causes a failure during linting for example when trying to use OpenTelemetry

