### PR TITLE
Fix throwError deprecated signature

### DIFF
--- a/src/app/core/interceptors/error.interceptor.ts
+++ b/src/app/core/interceptors/error.interceptor.ts
@@ -14,6 +14,8 @@ export class ErrorInterceptor implements HttpInterceptor {
     req: HttpRequest<any>,
     next: HttpHandler
   ): Observable<HttpEvent<any>> {
-    return next.handle(req).pipe(catchError((err) => throwError(err.error)));
+    return next
+      .handle(req)
+      .pipe(catchError((err) => throwError(() => err.error)));
   }
 }

--- a/src/app/features/article/article.component.ts
+++ b/src/app/features/article/article.component.ts
@@ -72,7 +72,7 @@ export class ArticleComponent implements OnInit, OnDestroy {
       .pipe(
         catchError((err) => {
           void this.router.navigate(["/"]);
-          return throwError(err);
+          return throwError(() => err);
         })
       )
       .subscribe(([article, comments, currentUser]) => {

--- a/src/app/features/profile/profile.component.ts
+++ b/src/app/features/profile/profile.component.ts
@@ -45,7 +45,7 @@ export class ProfileComponent implements OnInit, OnDestroy {
       .pipe(
         catchError((error) => {
           void this.router.navigate(["/"]);
-          return throwError(error);
+          return throwError(() => error);
         }),
         switchMap((profile) => {
           return combineLatest([of(profile), this.userService.currentUser]);


### PR DESCRIPTION
Passing an error directly to throwError is deprecated and instead, a factory function needs to be passed.